### PR TITLE
Fix for issue #7

### DIFF
--- a/ansible/roles/common/tasks/discos.yml
+++ b/ansible/roles/common/tasks/discos.yml
@@ -23,3 +23,11 @@
   become_flags: "-i"
   command: discos-get {{ branch }} -s {{ station }}
   when: branch == "master"
+
+- name: Increment the maximum number of user processes in order to run the AS
+  become: true
+  pam_limits:
+    domain: discos
+    limit_type: '-'
+    limit_item: nproc
+    value: 63266


### PR DESCRIPTION
The automatic deployment now sets the maximum number of user processes to 63266, as the standard value in most Linux distributions. Feel free to suggest a different, most appropriate value.