### PR TITLE
Fix #38. Provisioning machine public key deletion.

### DIFF
--- a/ansible/all.yml
+++ b/ansible/all.yml
@@ -19,3 +19,10 @@
   remote_user: "{{ user }}"
   roles:
     - manager
+
+
+- name: Delete the provisioning machine public key from provisioned hosts
+  hosts: all
+  remote_user: root
+  tasks:
+    - file: path=/root/.ssh state=absent

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -3,10 +3,8 @@
 - include: yum_packages.yml
 - include: network.yml
 
-
 - include: create_users_groups.yml
   when: discos_pwd is defined
-
 
 - include: required_tools.yml
 - include: acs.yml


### PR DESCRIPTION
Now a successful provisioning process deletes the provisioning machine public key (used to make ansible able to perform passwordless login after the first execution). The key was left in the provisioned machine but this may have caused security issues.