### PR TITLE
Fix #45, discos user variable moved.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,5 +1,5 @@
 ---
 
+user: discos
 local_repository_path: "{{ lookup('env','HOME') }}/repository"
 remote_build_path: /tmp/builds
-

--- a/ansible/roles/common/vars/main.yml
+++ b/ansible/roles/common/vars/main.yml
@@ -1,11 +1,4 @@
 ---
-#######################
-# DISCOS user variables
-#######################
-
-user: discos
-
-
 
 ###############
 # ACS Variables


### PR DESCRIPTION
The `user` variable it's still present in production environment, but this environment is going to be removed and split soon and the newer one will not have a `user` variable definition.