### PR TITLE
Fix #72. Installed fitsviewer tool.

### DIFF
--- a/ansible/roles/common/tasks/discos_dependencies.yml
+++ b/ansible/roles/common/tasks/discos_dependencies.yml
@@ -18,6 +18,11 @@
   register: ccfits_include
 
 
+- name: Check if fitsviewer is installed
+  stat: path=/usr/local/bin/fv
+  register: fv_binary
+
+
 - name: Check if the cfitsio sources exist in the local repository
   stat: path={{ local_repository_path }}/{{ cfitsio.file }}
   delegate_to: 127.0.0.1
@@ -28,6 +33,12 @@
   stat: path={{ local_repository_path }}/{{ ccfits.file }}
   delegate_to: 127.0.0.1
   register: ccfits_sources
+
+
+- name: Check if the fitsviewer binary exist in the local repository
+  stat: path={{ local_repository_path }}/{{ fv_file }}
+  delegate_to: 127.0.0.1
+  register: fv_archive
 
 
 - name: Download {{ cfitsio.file }}
@@ -49,6 +60,17 @@
   when:
     - ccfits_include.stat.exists == False
     - ccfits_sources.stat.exists == False
+  delegate_to: 127.0.0.1
+
+
+- name: Download {{ fv_file }}
+  get_url:
+    validate_certs: no
+    url: http://heasarc.gsfc.nasa.gov/FTP/software/lheasoft/fv/{{ fv_file }}
+    dest: "{{ local_repository_path }}"
+  when:
+    - fv_binary.stat.exists == False
+    - fv_archive.stat.exists == False
   delegate_to: 127.0.0.1
 
 
@@ -93,6 +115,21 @@
     - "{{ remote_build_path }}/{{ cfitsio.build_dir }}"
     - "{{ remote_build_path }}/{{ ccfits.build_dir }}"
 
+
+- name: Copy {{ fv_file }} to the remote /usr/local/lib
+  unarchive:
+    src={{ local_repository_path }}/{{ fv_file }}
+    dest=/usr/local/lib
+  when: fv_binary.stat.exists == False
+
+
+- lineinfile:
+    path: /usr/local/bin/fv
+    line: '/usr/local/lib/fv5.4/fv'
+    mode: 0755
+    state: present
+    create: yes
+  when: fv_binary.stat.exists == False
 
 
 #####################

--- a/ansible/roles/common/vars/main.yml
+++ b/ansible/roles/common/vars/main.yml
@@ -38,6 +38,7 @@ container_services: "{{ acssw }}/lib/python/site-packages/Acspy/Servants/Contain
 
 cfitsio: { file: 'cfitsio3370.tar.gz', build_dir: 'cfitsio' }
 ccfits: { file: 'CCfits-2.4.tar.gz', build_dir: 'CCfits' }
+fv_file: "fv5.4_pc_linux64.tar.gz"
 
 modbus: { file: 'libmodbus-3.0.6.tar.gz', build_dir: 'libmodbus-3.0.6' }
 


### PR DESCRIPTION
fv is installed in `/usr/local/lib` and a script named `fv` is installed in `/usr/local/bin`. The script is able to launch the fitsviewer tool from any directory without errors.