### PR TITLE
Fix #82. Forced locale to en_US.UTF-8.

### DIFF
--- a/ansible/roles/common/templates/bashrc
+++ b/ansible/roles/common/templates/bashrc
@@ -14,6 +14,21 @@ alias la='ls -A'
 alias lt='ls -lt | more'
 
 
+# Force en_US locale
+# ==================
+LANG="en_US.UTF-8"
+LC_ADDRESS="$LANG"
+LC_IDENTIFICATION="$LANG"
+LC_MEASUREMENT="$LANG"
+LC_MONETARY="$LANG"
+LC_NAME="$LANG"
+LC_NUMERIC="$LANG"
+LC_PAPER="$LANG"
+LC_TELEPHONE="$LANG"
+LC_TIME="$LANG"
+LC_ALL="$LANG"
+
+
 # Load ACS definitions
 # ====================
 if [ -f {{ acsconf_dir }}/.bash_profile.acs ]; then


### PR DESCRIPTION
This finally fixes the annoying bug that prevented the AntennaBoss component from starting correctly when using ssh access from a machine with different localization.