### PR TITLE
Fix #119, added VNC configuration.

### DIFF
--- a/ansible/group_vars/console
+++ b/ansible/group_vars/console
@@ -1,3 +1,8 @@
 ---
 
 observer: observer
+
+vnc_starting_port: 15000
+user_vnc_port: 1
+observer_vnc_port: 2
+vnc_resolution: 1920x1080

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -7,9 +7,6 @@
 - include: nis.yml
   when: network_domain_name is defined and nis_server_ip is defined
 
-- include: nfs.yml
-  when: network_domain_name is defined and network_ip_address is defined
-
 - include: create_discos.yml
 - include: required_tools.yml
 - include: acs.yml

--- a/ansible/roles/console/tasks/main.yml
+++ b/ansible/roles/console/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 
 - include: create_observer.yml
+- include: vnc.yml

--- a/ansible/roles/console/tasks/vnc.yml
+++ b/ansible/roles/console/tasks/vnc.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Configure tigervnc-server
+  lineinfile:
+    path: /etc/sysconfig/vncservers
+    line: "{{ item }}"
+    state: present
+  with_items:
+    - 'VNCSERVERS="1:{{ user }} 2:{{ observer }}"'
+    - 'VNCSERVERARGS[1]="-name {{ inventory_hostname }}-{{ user }} -localhost -SecurityTypes None -geometry {{ vnc_resolution }} -depth 32 -AlwaysShared -nolisten tcp -rfbport {{ vnc_starting_port+user_vnc_port|int }}"'
+    - 'VNCSERVERARGS[2]="-name {{ inventory_hostname }}-{{ observer }} -localhost -SecurityTypes None -geometry {{ vnc_resolution }} -depth 32 -AlwaysShared -nolisten tcp -rfbport {{ vnc_starting_port+observer_vnc_port|int }}"'
+  become: true
+
+
+- name: Deny ssh tunneling to user {{ observer }} for ports other than the VNC one
+  blockinfile:
+    path: "/etc/ssh/sshd_config"
+    state: present
+    marker: "##### {{ observer }} port forwarding configuration {mark} #####"
+    block: |
+        Match User {{ observer }}
+            PermitOpen localhost:{{ vnc_starting_port+observer_vnc_port|int }}
+
+
+- name: Restart ssh service
+  service:
+    name: sshd
+    state: restarted
+    enabled: yes
+
+
+- name: Start vncserver service
+  service:
+    name: vncserver
+    state: started
+    enabled: yes

--- a/ansible/roles/manager/tasks/main.yml
+++ b/ansible/roles/manager/tasks/main.yml
@@ -17,4 +17,7 @@
 - include: nis.yml
   when: nis_server_ip is defined
 
+- include: nfs.yml
+  when: network_domain_name is defined and network_ip_address is defined
+
 - include: guests.yml

--- a/ansible/roles/manager/tasks/nfs.yml
+++ b/ansible/roles/manager/tasks/nfs.yml
@@ -42,8 +42,8 @@
     state: present
     line: "{{ item }}"
   with_items:
-    - "exports          {{ network_ip_address }}   (ro, no_subtree_check, fsid=0, crossmnt)"
-    - "/exports/home    {{ network_ip_address }}   (rw, no_subtree_check, no_root_squash)"
+    - "exports          {{ network_ip_address }}(ro,no_subtree_check,fsid=0,crossmnt)"
+    - "/exports/home    {{ network_ip_address }}(rw,no_subtree_check,no_root_squash)"
   become: true
 
 


### PR DESCRIPTION
I decided to allow VNC sessions only when a secure ssh tunnel is
established. I also disabled the VNC password for both users (`discos`
and `observer`) since using the same password for both login and VNC is
a security flaw (VNC stores the password with a VERY weak encryption).
By forcing the remote users to type the `observer` login password to
establish the ssh tunnel, the VNC password is not required anymore. I
also defined a 'starting port' for VNC displays to everride the default
one (which is 5900+display number), since the default one collides with
some of the systems installed in the SRT station (and maybe in other
stations too). In order to prevent `observer` users to hijack the
`discos` user VNC session, I also configured a rule to allow `observer`
user to establish a ssh secure tunnel only for its VNC display port,
denying every other connection. I don't really know if this could become
an issue in the future, this must be discussed.