### PR TITLE
Fix #154, corrected the cleanup procedure.

### DIFF
--- a/ansible/all.yml
+++ b/ansible/all.yml
@@ -49,7 +49,5 @@
 - name: Remove the provisioning machine public key from provisioned hosts
   hosts: all
   remote_user: root
-  tasks:
-    - file:
-        path: /root/.ssh
-        state: absent
+  roles:
+    - cleanup

--- a/ansible/roles/cleanup/tasks/main.yml
+++ b/ansible/roles/cleanup/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Fetch the local user's public key
+  command: cat ~/.ssh/id_rsa.pub
+  register: local_public_key
+  delegate_to: 127.0.0.1
+  run_once: true
+
+
+- name: Remove the local user's public key from remote .ssh/authorized_hosts file
+  lineinfile:
+    path: ~/.ssh/authorized_keys
+    line: "{{ local_public_key.stdout }}"
+    state: absent


### PR DESCRIPTION
Now only the provisioning machine user's public key gets deleted, not all the `.ssh` directory.