### PR TITLE
Fix #185, fix #186, fix #187, see changelog below.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -11,6 +11,8 @@ user_uid: 3060
 observer: observer
 observer_uid: 3061
 
+discos_sw_dir: discos-sw
+
 local_repository_path: "{{ lookup('env','HOME') }}/repository"
 remote_build_path: /tmp/builds
 

--- a/ansible/roles/acs/tasks/acs.yml
+++ b/ansible/roles/acs/tasks/acs.yml
@@ -102,17 +102,17 @@
 ################################
 
 
-- name: Copy the .acs dir from /alma to /discos/config
+- name: Copy the .acs dir from /alma to /{{ discos_sw_dir }}/config
   command: chdir={{ acssw }}/config {{ item }}
   with_items:
-    - "cp -r .acs /discos/config/acs"
+    - "cp -r .acs /{{ discos_sw_dir }}/config/acs"
   become: true
   become_user: "{{ user }}"
 
 
 - name: Create the acstmp directory
   file:
-    path: "/data/acstmp/{{ inventory_hostname_short }}"
+    path: "/service/acstmp/{{ inventory_hostname_short }}"
     state: directory
     owner: "{{ user }}"
     group: acs

--- a/ansible/roles/acs/tasks/discos_environment.yml
+++ b/ansible/roles/acs/tasks/discos_environment.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: Populate the /discos/ directory tree
+- name: Populate the {{ discos_sw_dir }} directory tree
   file:
-    path: "/discos/{{ item.path }}"
+    path: "/{{ discos_sw_dir }}/{{ item.path }}"
     state: directory
     owner: "{{ user }}"
     group: acs
@@ -11,14 +11,14 @@
     follow: yes
   with_items:
     - { path: "config", mode: "0750" }
-    - { path: "config/discos", mode: "0750" }
+    - { path: "config/misc", mode: "0750" }
     - { path: "introots", mode: "0711" }
 
 
 - name: Copy the bashrc template
   template:
     src: bashrc
-    dest: "/discos/config/discos/"
+    dest: "/{{ discos_sw_dir }}/config/misc/"
     owner: "{{ user }}"
     group: acs
     mode: 0640
@@ -28,7 +28,7 @@
 - name: Copy prompt_command.sh
   template:
     src: prompt_command.sh
-    dest: "/discos/config/discos/"
+    dest: "/{{ discos_sw_dir }}/config/misc/"
     owner: "{{ user }}"
     group: acs
     mode: 0640
@@ -37,16 +37,17 @@
 
 - name: Create the branches file
   file:
-    path: "/discos/config/discos/branches"
+    path: "/{{ discos_sw_dir }}/config/misc/branches"
     state: touch
     owner: "{{ user }}"
     group: acs
+    mode: 0640
  
  
 - name: Copy the load_branch template
   template:
     src: load_branch
-    dest: "/discos/config/discos/"
+    dest: "/{{ discos_sw_dir }}/config/misc/"
     owner: "{{ user }}"
     group: acs
     mode: 0640
@@ -55,7 +56,7 @@
  
 - name: Create the /bin directory for user {{ user }}
   file:
-    path: "/discos/{{ user }}/bin"
+    path: "/{{ discos_sw_dir }}/{{ user }}/bin"
     state: directory
     owner: "{{ user }}"
     group: acs
@@ -65,7 +66,7 @@
 - name: Render the discos-get template
   template:
     src: discos-get
-    dest: "/discos/{{ user }}/bin/"
+    dest: "/{{ discos_sw_dir }}/{{ user }}/bin/"
     owner: "{{ user }}"
     group: acs
     mode: 0500
@@ -75,7 +76,7 @@
 - name: Render the discos-set template
   template:
     src: discos-set
-    dest: "/discos/{{ user }}/bin/"
+    dest: "/{{ discos_sw_dir }}/{{ user }}/bin/"
     owner: "{{ user }}"
     group: acs
     mode: 0500
@@ -85,7 +86,7 @@
 - name: Render the _discos-check-branch template
   template:
     src: _discos-check-branch
-    dest: "/discos/{{ user }}/bin/"
+    dest: "/{{ discos_sw_dir }}/{{ user }}/bin/"
     owner: "{{ user }}"
     group: acs
     mode: 0500
@@ -95,7 +96,7 @@
 - name: Copy the pyrc template
   template:
     src: pyrc
-    dest: "/discos/{{ item.name }}/.pyrc"
+    dest: "/{{ discos_sw_dir }}/{{ item.name }}/.pyrc"
     owner: "{{ item.name }}"
     group: acs
     mode: 0600
@@ -106,7 +107,7 @@
 - name: Copy vimrc
   template:
     src: vimrc
-    dest: "/discos/{{ item.name }}/.vimrc"
+    dest: "/{{ discos_sw_dir }}/{{ item.name }}/.vimrc"
     owner: "{{ item.name }}"
     group: acs
     mode: 0600
@@ -116,12 +117,12 @@
 
 - name: Add the custom bashrc sourcing to the default one
   blockinfile:
-    path: "/discos/{{ item.name }}/.bashrc"
+    path: "/{{ discos_sw_dir }}/{{ item.name }}/.bashrc"
     state: present
     marker: "######## DISCOS configuration {mark} ########"
     block: |
-        if [ -f /discos/config/discos/bashrc ]; then
-            source /discos/config/discos/bashrc
+        if [ -f /{{ discos_sw_dir }}/config/misc/bashrc ]; then
+            source /{{ discos_sw_dir }}/config/misc/bashrc
         fi
   no_log: true
   with_items: "{{ users }}"

--- a/ansible/roles/acs/tasks/utilities.yml
+++ b/ansible/roles/acs/tasks/utilities.yml
@@ -23,7 +23,7 @@
 - name: Copy the ipython startup files
   template:
     src: ipython_startup_01.py
-    dest: "/discos/{{ item.name }}/.ipython/profile_default/startup/01.py"
+    dest: "/{{ discos_sw_dir }}/{{ item.name }}/.ipython/profile_default/startup/01.py"
     owner: "{{ item.name }}"
     group: acs
     mode: 0644

--- a/ansible/roles/acs/templates/_discos-check-branch
+++ b/ansible/roles/acs/templates/_discos-check-branch
@@ -3,8 +3,8 @@ from __future__ import print_function
 import os, shutil
 
 BRANCH_ROOT = os.environ['HOME']
-BRANCH_LIST = os.path.join(BRANCH_ROOT, '/discos/config/discos/branches')
-load_branch = os.path.join(BRANCH_ROOT, '/discos/config/discos/load_branch')
+BRANCH_LIST = os.path.join(BRANCH_ROOT, '/{{ discos_sw_dir }}/config/misc/branches')
+load_branch = os.path.join(BRANCH_ROOT, '/{{ discos_sw_dir }}/config/misc/load_branch')
 
 discos_branch = ''
 
@@ -21,7 +21,7 @@ for line in open(BRANCH_LIST, 'r'):
         branches.append(branch)
     else:
         try:
-            shutil.rmtree('/discos/introots/%s' % branch)
+            shutil.rmtree('/{{ discos_sw_dir }}/introots/%s' % branch)
         except:
             pass
     lines = [b + '\n' for b in branches]

--- a/ansible/roles/acs/templates/bashrc
+++ b/ansible/roles/acs/templates/bashrc
@@ -12,16 +12,16 @@ alias lt='ls -lt | more'
 
 # Load ACS definitions
 # ====================
-if [ -f /discos/config/acs/.bash_profile.acs ]; then
-    source /discos/config/acs/.bash_profile.acs
+if [ -f /{{ discos_sw_dir }}/config/acs/.bash_profile.acs ]; then
+    source /{{ discos_sw_dir }}/config/acs/.bash_profile.acs
 fi
-export ACS_TMP=/data/acstmp/{{ inventory_hostname_short }}
+export ACS_TMP=/service/acstmp/{{ inventory_hostname_short }}
 
 
 # Load DISCOS environment
 # =======================
-if [ -f /discos/config/discos/load_branch ]; then
-    source /discos/config/discos/load_branch
+if [ -f /{{ discos_sw_dir }}/config/misc/load_branch ]; then
+    source /{{ discos_sw_dir }}/config/misc/load_branch
 fi
 
 
@@ -42,7 +42,7 @@ fi
 
 # Update the environment at every prompt
 # ======================================
-PROMPT_COMMAND='source /discos/config/discos/prompt_command.sh'
+PROMPT_COMMAND='source /{{ discos_sw_dir }}/config/misc/prompt_command.sh'
 
 
 # Variables to export
@@ -53,7 +53,7 @@ export QTINC=$QTDIR/include
 export qt_prefix=$QTLIB
 export PATH=$PATH:$QTDIR/bin:$HOME/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib64:$QTLIB
-export PYTHONSTARTUP=/discos/config/discos/.pyrc
+export PYTHONSTARTUP=/{{ discos_sw_dir }}/config/misc/.pyrc
 export EDITOR=vi
 {% if inventory_hostname not in groups['manager'] %}
 

--- a/ansible/roles/acs/templates/discos-get
+++ b/ansible/roles/acs/templates/discos-get
@@ -99,8 +99,8 @@ subprocess.call([
     'origin',
     'https://github.com/discos/discos.git'])
 
-# Create the introot inside /discos/introots/
-introot = os.path.join('/discos/introots', branch_name)
+# Create the introot inside /{{ discos_sw_dir }}/introots/
+introot = os.path.join('/{{ discos_sw_dir }}/introots', branch_name)
 code = subprocess.call(
     ['getTemplateForDirectory', 'INTROOT', introot],
     stdout=open(os.devnull, 'w'))
@@ -120,7 +120,7 @@ with open(os.path.join(introot, '.station'), 'w') as f:
     f.write(cargs.station)
 
 # Add the branch to the list of available branches
-with open('/discos/config/discos/branches', 'a+') as f:
+with open('/{{ discos_sw_dir }}/config/misc/branches', 'a+') as f:
     content = f.read()
     if not branch_name in content:
         f.write(branch_name + '\n')

--- a/ansible/roles/acs/templates/discos-set
+++ b/ansible/roles/acs/templates/discos-set
@@ -4,7 +4,7 @@ import argparse
 
 
 BRANCH_ROOT = os.environ['HOME']
-BRANCH_LIST = os.path.join(BRANCH_ROOT, '/discos/config/discos/branches')
+BRANCH_LIST = os.path.join(BRANCH_ROOT, '/{{ discos_sw_dir }}/config/misc/branches')
 
 with open(BRANCH_LIST, 'r') as f:
     declared_branches = [b.strip() for b in f.readlines()]
@@ -33,12 +33,12 @@ BRANCH_PATH = os.path.join(BRANCH_ROOT, args.branch)
 
 # Set the DISCOS_BRANCH environment variable
 lines = []
-load_branch = '/discos/config/discos/load_branch'
+load_branch = '/{{ discos_sw_dir }}/config/misc/load_branch'
 for line in open(load_branch):
     if 'export INTROOT=' in line:
-        lines.append('export INTROOT=/discos/introots/%s\n' % args.branch)
+        lines.append('export INTROOT=/{{ discos_sw_dir }}/introots/%s\n' % args.branch)
     elif 'export STATION=' in line:
-        with open('/discos/introots/%s/.station' % args.branch) as station:
+        with open('/{{ discos_sw_dir }}/introots/%s/.station' % args.branch) as station:
             lines.append('export STATION=%s\n' % station.readline().strip())
     elif 'export DISCOS_BRANCH=' in line:
         lines.append('export DISCOS_BRANCH=%s\n' % args.branch)
@@ -48,5 +48,5 @@ for line in open(load_branch):
         lines.append(line)
 open(load_branch, 'w').writelines(lines)
 
-os.symlink('/discos/introots/%s' % args.branch, '/discos/introots/tmp')
-os.rename('/discos/introots/tmp', '/discos/introots/default')
+os.symlink('/{{ discos_sw_dir }}/introots/%s' % args.branch, '/{{ discos_sw_dir }}/introots/tmp')
+os.rename('/{{ discos_sw_dir }}/introots/tmp', '/{{ discos_sw_dir }}/introots/default')

--- a/ansible/roles/acs/templates/load_branch
+++ b/ansible/roles/acs/templates/load_branch
@@ -9,8 +9,8 @@ export CDB=
 # =======================
 if [ -n "${DISCOS_BRANCH}" ]; then
     if [ $CDB = "test" ]; then
-        export ACS_CDB=/discos/{{ user }}/$DISCOS_BRANCH/$STATION
+        export ACS_CDB=/{{ discos_sw_dir }}/{{ user }}/$DISCOS_BRANCH/$STATION
     else
-        export ACS_CDB=/discos/{{ user }}/$DISCOS_BRANCH/$STATION/Configuration
+        export ACS_CDB=/{{ discos_sw_dir }}/{{ user }}/$DISCOS_BRANCH/$STATION/Configuration
     fi
 fi

--- a/ansible/roles/common/tasks/discos_users.yml
+++ b/ansible/roles/common/tasks/discos_users.yml
@@ -23,7 +23,7 @@
     - set_fact:
         users: [{ name: "{{ user }}", uid: "{{ user_uid }}", password: "{{ user_pwd }}" }]
     - set_fact:
-        users: "{{ users + [{ 'name': 'observer', 'uid': '{{ observer_uid }}', 'password': observer_pwd }] }}"
+        users: "{{ users }} + [{ 'name': observer, 'uid': observer_uid, 'password': observer_pwd }]"
       when: inventory_hostname in groups['console']
 
 
@@ -34,9 +34,9 @@
     state: present
 
 
-- name: Create the /discos directory
+- name: Create the /{{ discos_sw_dir }} directory
   file:
-    path: /discos
+    path: "/{{ discos_sw_dir }}"
     state: directory
     mode: 0755
 
@@ -47,7 +47,7 @@
     password: "{{ item.password }}"
     group: acs
     uid: "{{ item.uid }}"
-    home: "/discos/{{ item.name }}"
+    home: "/{{ discos_sw_dir }}/{{ item.name }}"
     state: present
     generate_ssh_key: yes
     ssh_key_file: .ssh/id_rsa
@@ -56,9 +56,9 @@
   when: item.password != ""
 
 
-- name: Tune the /discos directory ownership
+- name: Tune the /{{ discos_sw_dir }} directory ownership
   file:
-    path: /discos
+    path: "/{{ discos_sw_dir }}"
     state: directory
     owner: "{{ user }}"
     group: acs
@@ -108,7 +108,7 @@
   block:
     - name: Make sure the ssh files exists
       file:
-        path: "/discos/{{ user }}/.ssh/{{ item }}"
+        path: "/{{ discos_sw_dir }}/{{ user }}/.ssh/{{ item }}"
         state: touch
         owner: "{{ user }}"
         group: acs
@@ -118,7 +118,7 @@
         - "known_hosts"
     - name: Removing old machine RSA fingerprints from known_hosts file
       lineinfile:
-        path: /discos/{{ user }}/.ssh/known_hosts
+        path: /{{ discos_sw_dir }}/{{ user }}/.ssh/known_hosts
         state: absent
         regexp: "^{{ hostvars[item].inventory_hostname }},{{ hostvars[item].inventory_hostname_short}},{{ hostvars[item].ansible_host }}(.*)$"
       with_items: "{{ play_hosts }}"
@@ -127,23 +127,23 @@
       register: machine_public_key
     - name: Add machine RSA fingerprints to known_hosts file
       lineinfile:
-        path: /discos/{{ user }}/.ssh/known_hosts
+        path: /{{ discos_sw_dir }}/{{ user }}/.ssh/known_hosts
         state: present
         line: "{{ hostvars[item].inventory_hostname }},{{ hostvars[item].inventory_hostname_short}},{{ hostvars[item].ansible_host }} {{ hostvars[item].machine_public_key.stdout }}"
       with_items:
         - "{{ play_hosts }}"
     - name: Fetch the {{ user }} user RSA public key
-      command: cat /discos/{{ user }}/.ssh/id_rsa.pub
+      command: cat /{{ discos_sw_dir }}/{{ user }}/.ssh/id_rsa.pub
       register: user_public_key
     - name: Remove old public keys from authorized_keys file
       lineinfile:
-        path: /discos/{{ user }}/.ssh/authorized_keys
+        path: /{{ discos_sw_dir }}/{{ user }}/.ssh/authorized_keys
         state: absent
         regexp: "^(.*)ansible-generated on {{ hostvars[item].inventory_hostname_short }}$"
       with_items: "{{ play_hosts }}"
     - name: Share public key with all machines in current deployment session
       lineinfile:
-        path: /discos/{{ user }}/.ssh/authorized_keys
+        path: /{{ discos_sw_dir }}/{{ user }}/.ssh/authorized_keys
         state: present
         line: "{{ hostvars[item].user_public_key.stdout }}" 
       with_items:

--- a/ansible/roles/common/tasks/yum_packages.yml
+++ b/ansible/roles/common/tasks/yum_packages.yml
@@ -89,16 +89,19 @@
   when: inventory_hostname in groups['acs']
 
 
-- name: Install console required yum packages
-  block:
-    - yum:
+- block:
+    - name: Install the ius_release yum package on console machine
+      yum:
         name: "{{ ius_release }}"
         state: present
-    - yum:
+    - name: Install console required yum packages
+      yum:
         name: "{{ item }}"
         state: present
       with_items:
         - sshpass
+        - python27
+        - python27-pip
         - python36u-pip
         - python36u-devel
         - python36u-tkinter

--- a/ansible/roles/console/tasks/basie.yml
+++ b/ansible/roles/console/tasks/basie.yml
@@ -1,17 +1,8 @@
 ---
 
-- name: Install basie dependencies
-  yum:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - python27
-    - python27-pip
-
-
 - name: Create the basie directories
   file:
-    path: /discos/basie
+    path: /{{ discos_sw_dir }}/basie
     state: directory
     owner: "{{ user }}"
     group: acs
@@ -21,7 +12,7 @@
 - name: Copy the basie-get template
   template:
     src: basie-get
-    dest: /discos/basie/
+    dest: /{{ discos_sw_dir }}/basie/
     owner: "{{ user }}"
     group: acs
     mode: 0700
@@ -31,4 +22,4 @@
 - name: Execute the basie-get script
   command: ./basie-get
   args:
-    chdir: /discos/basie/
+    chdir: /{{ discos_sw_dir }}/basie/

--- a/ansible/roles/console/tasks/projects.yml
+++ b/ansible/roles/console/tasks/projects.yml
@@ -3,7 +3,7 @@
 - name: Render the discos-addProject template
   template:
     src: discos-addProject
-    dest: "/discos/{{ user }}/bin/"
+    dest: "/{{ discos_sw_dir }}/{{ user }}/bin/"
     owner: "{{ user }}"
     group: acs
     mode: 0544
@@ -15,7 +15,7 @@
 - name: Render the discos-removeProject template
   template:
     src: discos-removeProject
-    dest: "/discos/{{ user }}/bin/"
+    dest: "/{{ discos_sw_dir }}/{{ user }}/bin/"
     owner: "{{ user }}"
     group: acs
     mode: 0544

--- a/ansible/roles/console/tasks/sdtools.yml
+++ b/ansible/roles/console/tasks/sdtools.yml
@@ -23,14 +23,14 @@
     group: acs
     mode: "{{ item.mode }}"
   with_items:
-    - { path: "/discos/sdtools", mode: "0710" }
-    - { path: "/discos/sdtools/quicklook", mode: "0750" }
+    - { path: "/{{ discos_sw_dir }}/sdtools", mode: "0710" }
+    - { path: "/{{ discos_sw_dir }}/sdtools/quicklook", mode: "0750" }
 
 
 - name: Copy the sdtools-get template
   template:
     src: sdtools-get
-    dest: /discos/sdtools/
+    dest: "/{{ discos_sw_dir }}/sdtools/"
     owner: "{{ user }}"
     group: acs
     mode: 0700
@@ -40,7 +40,7 @@
 - name: Execute the sdtools-get script
   command: ./sdtools-get
   args:
-    chdir: /discos/sdtools/
+    chdir: "/{{ discos_sw_dir }}/sdtools/"
 
 
 - name: Copy the quicklook service template
@@ -54,7 +54,7 @@
 - name: Copy the quicklook configuration files
   template:
     src: "{{ item.src }}"
-    dest: /discos/sdtools/quicklook/
+    dest: "/{{ discos_sw_dir }}/sdtools/quicklook/"
     owner: "{{ user }}"
     group: acs
     mode: "{{ item.mode }}"
@@ -67,7 +67,7 @@
 
 - name: Make sure the Desktop directory exists for {{ observer }}
   file:
-    path: "/discos/{{ observer }}/Desktop"
+    path: "/{{ discos_sw_dir }}/{{ observer }}/Desktop"
     state: directory
     owner: "{{ observer }}"
     group: acs
@@ -76,8 +76,8 @@
 
 - name: Create a link to the quicklook index.html page
   file:
-    src: /discos/sdtools/quicklook/index.html
-    dest: "/discos/{{ observer }}/Desktop/quicklook.html"
+    src: "/{{ discos_sw_dir }}/sdtools/quicklook/index.html"
+    dest: "/{{ discos_sw_dir }}/{{ observer }}/Desktop/quicklook.html"
     state: link
     force: true
     owner: "{{ user }}"

--- a/ansible/roles/console/templates/bash_profile
+++ b/ansible/roles/console/templates/bash_profile
@@ -7,8 +7,8 @@ fi
 
 # User specific environment and startup programs
 
-PATH=$HOME/bin:/usr/local/bin:/discos/introots/default/user/bin:$PATH
+PATH=$HOME/bin:/usr/local/bin:/{{ discos_sw_dir }}/introots/default/user/bin:$PATH
 export PATH
 
-LD_LIBRARY_PATH=/discos/introots/default/lib
+LD_LIBRARY_PATH=/{{ discos_sw_dir }}/introots/default/lib
 export LD_LIBRARY_PATH

--- a/ansible/roles/console/templates/quicklook
+++ b/ansible/roles/console/templates/quicklook
@@ -2,7 +2,7 @@
 #. /etc/rc.d/init.d/functions
 #. /etc/sysconfig/network
 
-APP_PATH=/discos/sdtools/quicklook
+APP_PATH=/{{ discos_sw_dir }}/sdtools/quicklook
 
 start() {
     if [ -d /archive/data ]; then

--- a/ansible/roles/console/templates/service.conf
+++ b/ansible/roles/console/templates/service.conf
@@ -1,6 +1,6 @@
 <runner>
   user          discos
-  program       /discos/sdtools/quicklook/service.sh
+  program       /{{ discos_sw_dir }}/sdtools/quicklook/service.sh
   forever       True
   socket-name   service.sock
   exit-codes    0,2
@@ -11,7 +11,7 @@
 </runner>
 
 <environment>
-  HOME          /discos/discos
+  HOME          /{{ discos_sw_dir }}/{{ user }}
 </environment>
 
 <eventlog>

--- a/ansible/roles/console/templates/service.sh
+++ b/ansible/roles/console/templates/service.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cd /discos/sdtools/quicklook
+cd /{{ discos_sw_dir }}/sdtools/quicklook
 SDTmonitor -c monitor_config.ini --polling --nosave /archive/data/

--- a/ansible/roles/deploy/tasks/deploy.yml
+++ b/ansible/roles/deploy/tasks/deploy.yml
@@ -1,8 +1,8 @@
 ---
 
 - set_fact:
-    sources_path: "/discos/{{ user }}/{{ branch }}-{{ station }}"
-    introot_path: "/discos/introots/{{ branch }}-{{ station }}"
+    sources_path: "/{{ discos_sw_dir }}/{{ user }}/{{ branch }}-{{ station }}"
+    introot_path: "/{{ discos_sw_dir }}/introots/{{ branch }}-{{ station }}"
 
 
 - name: Remove the repository directory and introot (if present)

--- a/ansible/roles/manager/tasks/archive_tree.yml
+++ b/ansible/roles/manager/tasks/archive_tree.yml
@@ -27,19 +27,10 @@
     - [ "user::rwx", "group::---" ]
 
 
-- name: Create the DISCOS misc directory
-  file:
-    path: "/discos/{{ user }}/misc"
-    state: directory
-    owner: "{{ user }}"
-    group: acs
-    recurse: yes
-
-
 - name: Render the discos-logrotate template
   template:
     src: discos-logrotate
-    dest: "/discos/{{ user }}/misc/"
+    dest: "/{{ discos_sw_dir }}/config/misc/"
     owner: "{{ user }}"
     group: acs
     mode: 0644
@@ -52,4 +43,4 @@
     hour: "23"
     minute: "59"
     user: "{{ user }}"
-    job: "/usr/sbin/logrotate -f /discos/{{ user }}/misc/discos-logrotate"
+    job: "/usr/sbin/logrotate -f /{{ discos_sw_dir }}/config/misc/discos-logrotate"

--- a/ansible/roles/manager/templates/discos-logrotate
+++ b/ansible/roles/manager/templates/discos-logrotate
@@ -11,9 +11,9 @@
     extension .xml
     missingok
     compress
-    delaycompress
-#   postrotate
-#   endscript
+    postrotate
+        rsync /archive/events/*.gz /service/events/
+    endscript
 }
 
 #==========================================


### PR DESCRIPTION
Fix #185, reviewed the logrotation mechanism. Now the `acs.xml` file
gets immediately copied with the date on the name, it gets compressed
and then it gets copied to a local filesystem directory (the original
resides in the lustre partition).

Fix #186, in order to avoid confusion, the `/discos` directory, the
directory containing all discos-related users and stuff, has been
renamed to `/discos-sw`. Naming a directory with a user name identify a
user home directory, so the only directory named `discos` should be the
`discos` user home. With this in mind, the `/discos-sw/config/discos`
directory has been renamed to `/discos-sw/config/misc`.

Fix #187, the `/data` directory, the one containing the `acstmp`
directory, has been renamed to `/service`. This was due to the fact that
the name `data` should only identify observation's data.