### PR TITLE
Fix #200, improved the lustre server installation procedure.

### DIFF
--- a/ansible/inventories/development/group_vars/all
+++ b/ansible/inventories/development/group_vars/all
@@ -6,3 +6,7 @@ firewall_rules:
 
 network_domain_name: development.inaf.it
 network_ip_address: 192.168.10.0/24
+
+nis_server_ip: 192.168.10.200
+
+lustre_server_ip: 192.168.10.200

--- a/ansible/inventories/development/group_vars/discos
+++ b/ansible/inventories/development/group_vars/discos
@@ -1,4 +1,0 @@
----
-
-nis_server_ip: 192.168.10.200
-lustre_server_ip: 192.168.10.200

--- a/ansible/inventories/development/group_vars/storage
+++ b/ansible/inventories/development/group_vars/storage
@@ -2,7 +2,9 @@
 
 lustre_network_interface: enp0s8
 
+initialize_lustre_disk: true
+merge_mgs_mdt: true
+
 lustre_device: /dev/sdb
-lustre_mgs_partition: { device: "{{ lustre_device }}", number: 1, start: "0%", end: "2GiB" }
-lustre_mdt_partition: { device: "{{ lustre_device }}", number: 2, start: "{{ lustre_mgs_partition.end }}", end: "4GiB" }
-lustre_ost_partition: { device: "{{ lustre_device }}", number: 3, start: "{{ lustre_mdt_partition.end }}", end: "100%" }
+lustre_mgs_mdt_partition: { device: "{{ lustre_device }}", number: 1, start: "0%", end: "2GiB" }
+lustre_ost_partition: { device: "{{ lustre_device }}", number: 2, start: "{{ lustre_mgs_mdt_partition.end }}", end: "100%" }

--- a/ansible/roles/lustre/tasks/lustre_server.yml
+++ b/ansible/roles/lustre/tasks/lustre_server.yml
@@ -196,35 +196,63 @@
   parted:
     device: "{{ lustre_device }}"
     label: msdos
+  when: initialize_lustre_disk
+
+
+- set_fact:
+    lustre_mount_points:
+      - "/lustre"
+      - "/lustre/mgs-mdt"
+      - "/lustre/ost"
+  when: merge_mgs_mdt
+
+
+- set_fact:
+    lustre_mount_points:
+      - "/lustre"
+      - "/lustre/mgs"
+      - "/lustre/mdt"
+      - "/lustre/ost"
+  when: not merge_mgs_mdt
 
 
 - name: Create the lustre mount points
   file:
     path: "{{ item }}"
     state: directory
-  with_items:
-    - "/lustre"
-    - "/lustre/mgs"
-    - "/lustre/mdt"
-    - "/lustre/ost"
+  with_items: lustre_mount_points
 
 
-- name: Create the lustre mgs partition
+- name: Create the lustre mgs-mdt partition
   parted:
-    device: "{{ lustre_mgs_partition.device }}"
-    number: "{{ lustre_mgs_partition.number }}"
+    device: "{{ lustre_mgs_mdt_partition.device }}"
+    number: "{{ lustre_mgs_mdt_partition.number }}"
     state: present
-    part_start: "{{ lustre_mgs_partition.start }}"
-    part_end: "{{ lustre_mgs_partition.end }}"
+    part_start: "{{ lustre_mgs_mdt_partition.start }}"
+    part_end: "{{ lustre_mgs_mdt_partition.end }}"
+  when:
+    - initialize_lustre_disk
+    - merge_mgs_mdt
 
 
-- name: Create the lustre mdt partition
-  parted:
-    device: "{{ lustre_mdt_partition.device }}"
-    number: "{{ lustre_mdt_partition.number }}"
-    state: present
-    part_start: "{{ lustre_mdt_partition.start }}"
-    part_end: "{{ lustre_mdt_partition.end }}"
+- block:
+  - name: Create the lustre mgs partition
+    parted:
+      device: "{{ lustre_mgs_partition.device }}"
+      number: "{{ lustre_mgs_partition.number }}"
+      state: present
+      part_start: "{{ lustre_mgs_partition.start }}"
+      part_end: "{{ lustre_mgs_partition.end }}"
+  - name: Create the lustre mdt partition
+    parted:
+      device: "{{ lustre_mdt_partition.device }}"
+      number: "{{ lustre_mdt_partition.number }}"
+      state: present
+      part_start: "{{ lustre_mdt_partition.start }}"
+      part_end: "{{ lustre_mdt_partition.end }}"
+  when:
+    - initialize_lustre_disk
+    - not merge_mgs_mdt
 
 
 - name: Create the lustre data partition
@@ -234,42 +262,63 @@
     state: present
     part_start: "{{ lustre_ost_partition.start }}"
     part_end: "{{ lustre_ost_partition.end }}"
+  when: initialize_lustre_disk
 
 
-- name: Format the lustre mgs partition
-  command: "mkfs.lustre --mgs {{ lustre_mgs_partition.device}}{{ lustre_mgs_partition.number }}"
+- name: Format the lustre mgs-mdt partition
+  command: "mkfs.lustre --fsname=discos --mgs --mdt {{ lustre_mgs_mdt_partition.device}}{{ lustre_mgs_mdt_partition.number }}"
   register: command_result
   failed_when:
     - command_result.rc != 0
     - command_result.rc != 1
     - command_result.rc != 17
+  when: merge_mgs_mdt
 
 
-- name: Format the lustre mdt partition
-  command: "mkfs.lustre --mdt --fsname=discos --mgsnode={{ lustre_server_ip }}@tcp --index=0 {{ lustre_mdt_partition.device}}{{ lustre_mdt_partition.number }}"
-  register: command_result
-  failed_when:
-    - command_result.rc != 0
-    - command_result.rc != 1
-    - command_result.rc != 17
+- block:
+  - name: Format the lustre mgs partition
+    command: "mkfs.lustre --mgs {{ lustre_mgs_partition.device}}{{ lustre_mgs_partition.number }}"
+    register: command_result
+    failed_when:
+      - command_result.rc != 0
+      - command_result.rc != 1
+      - command_result.rc != 17
+  - name: Format the lustre mdt partition
+    command: "mkfs.lustre --mdt --fsname=discos --mgsnode={{ lustre_server_ip }}@tcp --index=0 {{ lustre_mdt_partition.device}}{{ lustre_mdt_partition.number }}"
+    register: command_result
+    failed_when:
+      - command_result.rc != 0
+      - command_result.rc != 1
+      - command_result.rc != 17
+  when: not merge_mgs_mdt
 
 
-- name: Mount the lustre mgs partition
+- name: Mount the lustre mgs-mdt partition
   mount:
-    path: /lustre/mgs
-    src: "{{ lustre_mgs_partition.device }}{{ lustre_mgs_partition.number }}"
-    fstype: lustre
-    state: mounted
-    opts: defaults
-
-
-- name: Mount the lustre mdt partition
-  mount:
-    path: /lustre/mdt
-    src: "{{ lustre_mdt_partition.device }}{{ lustre_mdt_partition.number }}"
+    path: /lustre/mgs-mdt
+    src: "{{ lustre_mgs_mdt_partition.device }}{{ lustre_mgs_mdt_partition.number }}"
     fstype: lustre
     state: mounted
     opts: defaults,abort_recovery
+  when: merge_mgs_mdt
+
+
+- block:
+  - name: Mount the lustre mgs partition
+    mount:
+      path: /lustre/mgs
+      src: "{{ lustre_mgs_partition.device }}{{ lustre_mgs_partition.number }}"
+      fstype: lustre
+      state: mounted
+      opts: defaults
+  - name: Mount the lustre mdt partition
+    mount:
+      path: /lustre/mdt
+      src: "{{ lustre_mdt_partition.device }}{{ lustre_mdt_partition.number }}"
+      fstype: lustre
+      state: mounted
+      opts: defaults,abort_recovery
+  when: not merge_mgs_mdt
 
 
 - name: Format the lustre data partition


### PR DESCRIPTION
The disk initialization is now optional. In order for for the procedure
to perform it, the `initialize_lustre_disk` variable should be set to
true in the `<inventory>/group_vars/storage` file. If this strategy is
adopted, the `lustre_<XXX>_partition` variables can leave out the
`start` and the `end` fields.

The procedure also handles a mixed `mgs` and `mdt` lustre partition. In
order to enable this feature, the `merge_mgs_mdt` variable should be set
to true in the `<inventory>/group_vars/storage` file. Also, variables
`lustre_mgs_partition` and `lustre_mdt_partition` should be replaced by
the `lustre_mgs_mdt_partition`, keeping the same format.