### PR TITLE
Fix #203, disabled kernel updates.

### DIFF
--- a/ansible/roles/finalize/tasks/fix_kernel.yml
+++ b/ansible/roles/finalize/tasks/fix_kernel.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Disable future kernel updates
+  lineinfile:
+    dest: /etc/yum.conf
+    line: "exclude=kernel*"

--- a/ansible/roles/finalize/tasks/main.yml
+++ b/ansible/roles/finalize/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
 
+- include: fix_kernel.yml
 - include: remount.yml
 - include: cleanup.yml


### PR DESCRIPTION
The task gets performed during the `finalize` role, at the end of the provisioning procedure, in order to be able to install lustre kernel packages.