### PR TITLE
Fix #209, hosts template can add arbitrary defined hosts.

### DIFF
--- a/ansible/roles/common/templates/hosts
+++ b/ansible/roles/common/templates/hosts
@@ -1,7 +1,11 @@
 127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
 
 {% for hostname in groups['discos'] %}
-{% if inventory_hostname != hostvars[hostname].inventory_hostname %}
 {{ hostvars[hostname].ansible_host }} {{ hostvars[hostname].inventory_hostname }} {{ hostvars[hostname].inventory_hostname_short }}
-{% endif %}
 {% endfor %}
+
+{% if host_list is defined %}
+{% for machine in host_list %}
+{{ machine.ip_address }} {{ machine.hostname }}{{ network_domain_name }} {{ machine.hostname }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Also, every machine now can find itself in the hosts file. This can prevent some network, DNS-related, issues.