### PR TITLE
Fix #216, use provisioning machine as default NTP server in development.

### DIFF
--- a/ansible/roles/common/tasks/time.yml
+++ b/ansible/roles/common/tasks/time.yml
@@ -5,6 +5,12 @@
     name: Etc/UTC
 
 
+- name: Set the NTP server IP address
+  set_fact:
+    ntp_server_ip: "{{ ansible_facts.env.SSH_CLIENT.split()[0] }}"
+  when: ntp_server_ip is not defined
+
+
 - name: Copy the ntp.conf template
   template:
     src: ntp.conf


### PR DESCRIPTION
This only applies when the `ntp_server_ip` variable is not defined. For the production environments, if the said variable is defined, the new task gets simply ignored.