### PR TITLE
Fix #190, added a way to let the quicklook monitor multiple directories.

### DIFF
--- a/ansible/inventories/development/group_vars/console
+++ b/ansible/inventories/development/group_vars/console
@@ -1,3 +1,6 @@
 ---
 
 lustre_network_interface: eth1
+
+quicklook_directories:
+  - "/archive/data"

--- a/ansible/inventories/srt/group_vars/console
+++ b/ansible/inventories/srt/group_vars/console
@@ -1,3 +1,7 @@
 ---
 
 lustre_network_interface: p1p1
+
+quicklook_directories:
+  - "/archive/data"
+  - "{{ sardara_mount_point }}"

--- a/ansible/roles/console/tasks/main.yml
+++ b/ansible/roles/console/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 
 - include: sdtools.yml
+- include: quicklook.yml
+  when: quicklook_directories is defined
 - include: basie.yml
 - include: projects.yml

--- a/ansible/roles/console/tasks/quicklook.yml
+++ b/ansible/roles/console/tasks/quicklook.yml
@@ -1,0 +1,50 @@
+---
+
+- name: Copy the quicklook service template
+  template:
+    src: quicklook
+    dest: /etc/rc.d/init.d/quicklook
+    mode: 0755
+    force: true
+
+
+- name: Create the sdtools/quicklook directory
+  file:
+    path: "/{{ discos_sw_dir }}/sdtools/quicklook"
+    state: directory
+    owner: "{{ user }}"
+    group: acs
+    mode: 0750
+
+
+- name: Copy the quicklook configuration files
+  template:
+    src: "{{ item }}"
+    dest: "/{{ discos_sw_dir }}/sdtools/quicklook/"
+    owner: "{{ user }}"
+    group: acs
+    mode: 0640
+    force: true
+  with_items:
+    - "monitor_config.ini"
+    - "service.conf"
+
+
+- name: Make sure the Desktop directory exists for {{ observer }}
+  file:
+    path: "/{{ discos_sw_dir }}/{{ observer }}/Desktop"
+    state: directory
+    owner: "{{ observer }}"
+    group: acs
+    mode: 0755
+
+
+- name: Create a link to the quicklook index.html page
+  file:
+    src: "/{{ discos_sw_dir }}/sdtools/quicklook/index.html"
+    dest: "/{{ discos_sw_dir }}/{{ observer }}/Desktop/quicklook.html"
+    state: link
+    force: true
+    owner: "{{ user }}"
+    group: acs
+    mode: 0644

--- a/ansible/roles/console/tasks/sdtools.yml
+++ b/ansible/roles/console/tasks/sdtools.yml
@@ -1,12 +1,5 @@
 ---
 
-- name: Make sure the quicklook service is not running
-  service:
-    name: quicklook
-    status: stopped
-  failed_when: false
-
-
 - name: Install SDTools dependencies
   command: "pip3.6 install {{ item }}"
   with_items:
@@ -22,16 +15,13 @@
     - Zdaemon
 
 
-- name: Create the sdtools directories
+- name: Create the sdtools directory
   file:
-    path: "{{ item.path }}"
+    path: "/{{ discos_sw_dir }}/sdtools"
     state: directory
     owner: "{{ user }}"
     group: acs
-    mode: "{{ item.mode }}"
-  with_items:
-    - { path: "/{{ discos_sw_dir }}/sdtools", mode: "0710" }
-    - { path: "/{{ discos_sw_dir }}/sdtools/quicklook", mode: "0750" }
+    mode: 0710
 
 
 - name: Copy the sdtools-get template
@@ -48,44 +38,3 @@
   command: ./sdtools-get
   args:
     chdir: "/{{ discos_sw_dir }}/sdtools/"
-
-
-- name: Copy the quicklook service template
-  template:
-    src: quicklook
-    dest: /etc/rc.d/init.d/quicklook
-    mode: 0755
-    force: true
-
-
-- name: Copy the quicklook configuration files
-  template:
-    src: "{{ item.src }}"
-    dest: "/{{ discos_sw_dir }}/sdtools/quicklook/"
-    owner: "{{ user }}"
-    group: acs
-    mode: "{{ item.mode }}"
-    force: true
-  with_items:
-    - { src: "monitor_config.ini", mode: "0640" }
-    - { src: "service.conf", mode: "0640" }
-
-
-- name: Make sure the Desktop directory exists for {{ observer }}
-  file:
-    path: "/{{ discos_sw_dir }}/{{ observer }}/Desktop"
-    state: directory
-    owner: "{{ observer }}"
-    group: acs
-    mode: 0755
-
-
-- name: Create a link to the quicklook index.html page
-  file:
-    src: "/{{ discos_sw_dir }}/sdtools/quicklook/index.html"
-    dest: "/{{ discos_sw_dir }}/{{ observer }}/Desktop/quicklook.html"
-    state: link
-    force: true
-    owner: "{{ user }}"
-    group: acs
-    mode: 0644

--- a/ansible/roles/console/templates/service.conf
+++ b/ansible/roles/console/templates/service.conf
@@ -1,6 +1,6 @@
 <runner>
   user          discos
-  program       /usr/bin/SDTmonitor -c monitor_config.ini --polling --nosave /archive/data
+  program       /usr/bin/SDTmonitor -c monitor_config.ini --polling --nosave {{ quicklook_directories | join(' ') }}
   forever       True
   socket-name   service.sock
   exit-codes    0,2


### PR DESCRIPTION
To allow this, a list of directories to be monitored should be defined as `quicklook_directories` in the `ansible/inventories/<inventory>/group_vars/console` file. If this variable is not defined, Ansible will install the single dish tools but not the quicklook service.