### PR TITLE
Fix #249, fixed the development storage machine lustre network interface

### DIFF
--- a/ansible/inventories/development/group_vars/storage
+++ b/ansible/inventories/development/group_vars/storage
@@ -1,6 +1,6 @@
 ---
 
-lustre_network_interface: enp0s8
+lustre_network_interface: eth1
 
 initialize_lustre_disk: true
 merge_mgs_mdt: true

--- a/ansible/roles/lustre/tasks/check_interfaces.yml
+++ b/ansible/roles/lustre/tasks/check_interfaces.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Gather network interfaces list
+  shell: ifconfig -a | sed 's/[ :].*//;/^\(lo\|\)$/d'
+  register: network_interfaces
+
+
+- name: Parse the network interfaces list
+  set_fact:
+    network_interfaces: "{{ network_interfaces.stdout.split('\n') }}"
+
+
+- name: Check if lustre_network_interface is listed
+  fail:
+    msg: "Interface {{ lustre_network_interface }} not present in the system! Choose among {{ ', '.join(network_interfaces) }}"
+  when: lustre_network_interface not in network_interfaces

--- a/ansible/roles/lustre/tasks/main.yml
+++ b/ansible/roles/lustre/tasks/main.yml
@@ -2,6 +2,7 @@
 
 - block:
     - include: key_exchange.yml
+    - include: check_interfaces.yml
     - include: lustre_clients.yml
       when: inventory_hostname in groups['acs']
     - include: lustre_server.yml


### PR DESCRIPTION
Also, written some new tasks that check if the selected interface is
available in the system. If the interface is not found the procedure
will stop specifying the names of the available interfaces, in order for
the developers to update the `lustre_network_interface` variable with
the correct one.