### PR TITLE
Fix #254, fixed the ACS log rotation file

### DIFF
--- a/ansible/roles/manager/templates/discos-logrotate
+++ b/ansible/roles/manager/templates/discos-logrotate
@@ -11,7 +11,7 @@
     extension .xml
     missingok
     compress
-    postrotate
+    lastaction
         rsync /archive/events/*.gz /service/events/
     endscript
 }


### PR DESCRIPTION
Replaced the 'postrotate' line with `lastaction`. This was needed in order for the script to be able to work on the compressed log file.