### PR TITLE
Fix #281, increased Ansible reboot role timeout

### DIFF
--- a/ansible/roles/reboot/tasks/main.yml
+++ b/ansible/roles/reboot/tasks/main.yml
@@ -10,8 +10,8 @@
 
 - name: Wait for machine to come back online
   wait_for_connection:
-    connect_timeout: 20
+    connect_timeout: 5
     sleep: 5
     delay: 5
-    timeout: 300
+    timeout: 600
   when: rebooting is changed


### PR DESCRIPTION
The time to wait for a machine to be back online after a reboot was increased from 300 seconds to 600 (600 is the Ansible default value).