### PR TITLE
Fix #285, added receivers monitor to startup.

### DIFF
--- a/ansible/inventories/srt/group_vars/console
+++ b/ansible/inventories/srt/group_vars/console
@@ -7,3 +7,5 @@ quicklook_directories:
   - "{{ sardara_mount_point }}"
 
 quicklook_server_port: 8080
+
+monitor_receivers = True

--- a/ansible/roles/acs/defaults/main.yml
+++ b/ansible/roles/acs/defaults/main.yml
@@ -84,3 +84,10 @@ pyqwt_url: "{{ pyqwt_base_path }}/{{ pyqwt_version }}/{{ pyqwt_file }}"
 git_orig: { base: "https://github.com/git/git/archive/", version: "2.18.0", extension: ".tar.gz" }
 git_dest: { file: 'git-v{{ git_orig.version }}{{ git_orig.extension }}' }
 ghtoken: 47aabb9fb8a55376eb43ede8e375a774e8e50b3b
+
+
+################
+# Misc Variables
+################
+
+monitor_receivers: False

--- a/ansible/roles/acs/tasks/main.yml
+++ b/ansible/roles/acs/tasks/main.yml
@@ -6,3 +6,6 @@
 - include: acs.yml
 - include: discos_dependencies.yml
 - include: utilities.yml
+- include: receivers_monitor.yml
+  when:
+    - monitor_receivers == True

--- a/ansible/roles/acs/tasks/receivers_monitor.yml
+++ b/ansible/roles/acs/tasks/receivers_monitor.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Create the /service/receivers directory
+  file:
+    path: "/service/receivers"
+    state: directory
+    owner: "{{ user.name }}" 
+    group: "{{ user.group }}"
+    mode: 0755
+    recurse: True
+
+
+- name: Add receivers monitoring script to rc.local 
+  blockinfile:
+    path: "/etc/rc.local"
+    state: present
+    marker: "######## Receivers monitoring {mark} ########"
+    block: |
+        if [ -f /{{ discos_sw_dir }}/introots/default/bin/receiversmonitor.py ]; then
+            runuser -l {{ user.name }} -c 'receiversmonitor.py &'
+        fi


### PR DESCRIPTION
In order to enable this task, the variable `monitor_receivers` should be set to true in the inventory.