### PR TITLE
Fix #320, aliased the make command when inside the wrong discos branch

### DIFF
--- a/ansible/roles/acs/templates/prompt_command.sh
+++ b/ansible/roles/acs/templates/prompt_command.sh
@@ -4,6 +4,11 @@ if [ -f $HOME/bin/_discos-check-branch ]; then
 	CHECK_OUTPUT=$($HOME/bin/_discos-check-branch)
 	if [ -n "${CHECK_OUTPUT}" ]; then
 		echo -e "${pur}WARNING:${txtrst} $CHECK_OUTPUT"
+        alias make="
+        echo -e \"${pur}WARNING:${txtrst} the make command has been disabled in order to avoid messing up the default introot!\"
+        echo \"         Set your desired branch using the 'discos-set' command before compiling and installing!\""
+    else
+        unalias make 2>/dev/null
 	fi
 fi
 


### PR DESCRIPTION
This is the make command behavior after this addition:
`(master-srt:telescope) discos@manager ~ $ cd stable-srt/`
`WARNING: you are in 'stable-srt', but the active branch is 'master-srt'`
`(master-srt:telescope) discos@manager ~/stable-srt $ make`
`WARNING: the make command has been disabled in order to avoid messing up the default introot!`
`         Set your desired branch using the 'discos-set' command before compiling and installing!`
`WARNING: you are in 'stable-srt', but the active branch is 'master-srt'`
`(master-srt:telescope) discos@manager ~/stable-srt $ cd`
`(master-srt:telescope) discos@manager ~ $ make`
`make: *** No targets specified and no makefile found.  Stop.`

This will block the developer from installing some discos software inside the wrong introot