### PR TITLE
Fix #348, python-argparse will be installed in ACS machines

### DIFF
--- a/ansible/roles/acs/tasks/yum.yml
+++ b/ansible/roles/acs/tasks/yum.yml
@@ -76,6 +76,7 @@
       - java-1.8.0-openjdk
       - git-core
       - bash-completion
+      - python-argparse
       - "@X Window System"
       - "@Desktop"
       - "@fonts"


### PR DESCRIPTION
This will always be executed before trying to install the SDTools