### PR TITLE
Fix #379, added SAOImageDS9 to console machines

### DIFF
--- a/ansible/development.yml
+++ b/ansible/development.yml
@@ -121,6 +121,13 @@
     - gildas
 
 
+- name: Install SAOImageDS9
+  hosts: manager
+  remote_user: root
+  roles:
+    - ds9
+
+
 - name: Apply configuration for project users
   hosts: manager
   remote_user: root

--- a/ansible/medicina.yml
+++ b/ansible/medicina.yml
@@ -154,6 +154,13 @@
     - gildas
 
 
+- name: Install SAOImageDS9
+  hosts: console
+  remote_user: root
+  roles:
+    - ds9
+
+
 - name: Apply configuration for project users
   hosts: console
   remote_user: root

--- a/ansible/noto.yml
+++ b/ansible/noto.yml
@@ -121,6 +121,13 @@
     - gildas
 
 
+- name: Install SAOImageDS9
+  hosts: manager
+  remote_user: root
+  roles:
+    - ds9
+
+
 - name: Apply configuration for project users
   hosts: manager
   remote_user: root

--- a/ansible/roles/ds9/defaults/main.yml
+++ b/ansible/roles/ds9/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+ds9: "ds9.centos6.8.0.tar.gz"

--- a/ansible/roles/ds9/tasks/main.yml
+++ b/ansible/roles/ds9/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Download {{ ds9 }} archive
+  get_url:
+    url: "{{ remote_repository_download_url }}/{{ ds9 }}"
+    dest: "{{ local_repository_path }}"
+    force: false
+    headers:
+      Authorization: "token {{ repository_token }}"
+  delegate_to: localhost
+  run_once: true
+
+
+- name: Extract the {{ ds9 }} archive to the remote
+  unarchive:
+    src: "{{ local_repository_path }}/{{ ds9 }}"
+    dest: "/usr/bin/"
+    mode: 0755

--- a/ansible/srt.yml
+++ b/ansible/srt.yml
@@ -154,6 +154,13 @@
     - gildas
 
 
+- name: Install SAOImageDS9
+  hosts: console
+  remote_user: root
+  roles:
+    - ds9
+
+
 - name: Apply configuration for project users
   hosts: console
   remote_user: root


### PR DESCRIPTION
In development and Noto lines, the tool has been added to manager
machines since a console is not present