### PR TITLE
Fix #402, updated Ansible Simulators role

### DIFF
--- a/ansible/roles/simulators/tasks/main.yml
+++ b/ansible/roles/simulators/tasks/main.yml
@@ -16,7 +16,6 @@
   become_user: "{{ user.name }}"
   become_flags: "-i"
   with_items:
-    - "pyenv local 2.7.16"
     - "pip install -r requirements.txt"
     - "python setup.py install"
     - "pyenv rehash"

--- a/ansible/roles/simulators/tasks/main.yml
+++ b/ansible/roles/simulators/tasks/main.yml
@@ -19,6 +19,5 @@
     - "pip install -r requirements.txt"
     - "python setup.py install"
     - "pyenv rehash"
-    - "pyenv local --unset"
   args:
     chdir: "/{{ discos_sw_dir }}/simulators/"


### PR DESCRIPTION
DISCOS simulators now get installed in the Python 3.9.6 environment