### PR TITLE
Fix #412, updated ACS Python 3 default version

### DIFF
--- a/ansible/roles/acs/tasks/acs.yml
+++ b/ansible/roles/acs/tasks/acs.yml
@@ -69,6 +69,19 @@
   when: target_dir.stat.exists == False
 
 
+- name: Patch ACS Python 3 default version
+  template:
+    src: "patches/{{ acs_tag }}/{{ item }}"
+    dest: "{{ remote_build_path }}/acs/ExtProd/INSTALL"
+    owner: "{{ user.name }}"
+    group: "{{ user.group }}"
+    mode: 0755
+  with_items:
+    - "buildPython"
+    - "buildPyModules"
+    - "buildOmniORB"
+
+
 - name: Install ACS ExtProd
   shell: 'source {{ remote_build_path }}/acs/LGPL/acsBUILD/config/.acs/.bash_profile.acs && make all && find /alma -name "*.o" -exec rm -v {} \;'
   args:

--- a/ansible/roles/acs/templates/patches/ACS-2021DEC/buildOmniORB
+++ b/ansible/roles/acs/templates/patches/ACS-2021DEC/buildOmniORB
@@ -1,0 +1,181 @@
+#! /bin/bash
+#*******************************************************************************
+# E.S.O. - ALMA project
+#
+# "@(#) $Id: buildOmniORB,v 1.22 2012/01/09 14:39:47 tstaig Exp $"
+#
+# who       when        what
+# --------  ----------  ----------------------------------------------
+# psivera   2002-08-21  created
+# psivera   2002-09-25  added mv of directories after unzip
+# sturolla  2002-09-25  ported to Bourne Shell and added external subroutin to determine OS 
+#
+
+#************************************************************************
+#   NAME
+#
+#   SYNOPSIS
+#
+#   DESCRIPTION
+#
+#   FILES
+#
+#   ENVIRONMENT
+#
+#   RETURN VALUES
+#
+#   CAUTIONS
+#
+#   EXAMPLES
+#
+#   SEE ALSO
+#
+#   BUGS
+#
+#------------------------------------------------------------------------
+#
+
+#set -x 
+
+# Load functions
+. standardUtilities
+#
+# Fetch operating system and release version
+#
+os_discovery
+
+
+LOG=buildOmniORB.log
+#
+exec > $LOG 2>&1
+
+date
+
+#
+# Install omniORB.  This deletes and rebuilds the $OMNI_ROOT
+# It will ftp the distribution files if they are not found.
+#
+# NOTE: need to set OMNI_ROOT, PYTHON, and TICS_PGS.
+# Source ENV.sh to do this.
+#
+# Reference to omniORB:
+#	http://omniorb.sourceforge.net/download.html
+#
+echo installing the omniORB distribution
+eval "$(pyenv init -)"
+#
+# omniORB ORB - omniORB-4.1.4.tar.gz
+# 
+# Notes: omni/README.FIRST, omni/README.unix
+#
+# Edit config/config.mk and set the platform:
+#   platform = i586_linux_2.0_glibc2.1
+#
+# Edit mk/platforms/i586_linux_2.0_glibc2.1.mk
+#   PYTHON = /home/alma/packages/bin/python
+#
+export OMNIORB_VERSION="4.2.4"
+
+function build_omniorb_for_python () {
+    export PYTHON_ROOT="$1"
+    export OMNI_ROOT="$PWD/../PRODUCTS/omniORB-$OMNIORB_VERSION"
+    echo "Building OmniORB for $PYTHON_ROOT with sources in $OMNI_ROOT"
+
+    if [ ! -e ../PRODUCTS/omniORB-$OMNIORB_VERSION.tar.bz2 ]
+    then
+      echo Error: omniORB-$OMNIORB_VERSION sources are missing
+      exit 2
+    fi
+    
+    CWD=`pwd`
+    cd ../PRODUCTS
+    rm -rf omniORB-$OMNIORB_VERSION
+    tar -jxf omniORB-$OMNIORB_VERSION.tar.bz2
+    cd $OMNI_ROOT
+    
+    #
+    # change configuration files
+    #
+    NUM_CPU=`grep -c processor  /proc/cpuinfo`
+    if [ "$OS" = "LINUX" ] || [ "$OS" = "SOLARIS" ] || [ "$OS" = "$CYGWIN_VER" ]
+    then
+        mkdir build
+        cd build
+        ../configure --prefix=$PYTHON_ROOT PYTHON=$PYTHON_ROOT/bin/python LDFLAGS="-Wl,-rpath -Wl,$PYTHON_ROOT/lib"
+        make -j $NUM_CPU
+        make install
+    else
+        echo "OS $OS is not supported"
+        exit 1
+    fi
+    
+    cd $CWD
+    
+    #
+    # omniORB Python
+    #
+    # Notes: See omniORBpy/ReleaseNote for help
+    #
+    if [ ! -e ../PRODUCTS/omniORBpy-$OMNIORB_VERSION.tar.bz2 ]
+    then
+      echo Error: omniORBpy-$OMNIORB_VERSION sources are missing
+      exit 2
+    fi
+    
+    cd ../PRODUCTS
+    tar -jxf omniORBpy-$OMNIORB_VERSION.tar.bz2 -C $OMNI_ROOT/src/lib
+    
+    cp omniORB-patches/CosProperty.idl $OMNI_ROOT/idl/COS
+    
+    mkdir -p $OMNI_ROOT/src/lib/
+    mv $OMNI_ROOT/src/lib/omniORBpy-$OMNIORB_VERSION $OMNI_ROOT/src/lib/omniORBpy
+    cd $OMNI_ROOT/src/lib/omniORBpy
+    mkdir -p build
+    cd build
+    ../configure --prefix=$PYTHON_ROOT PYTHON=$PYTHON_ROOT/bin/python  LDFLAGS="-Wl,-rpath -Wl,$PYTHON_ROOT/lib"
+    make -j $NUM_CPU
+    make install
+
+    rsync -a $OMNI_ROOT/idl $PYTHON_ROOT/
+    #
+    # Depending on the version of python installed and used for building,
+    # the code generated will be put in python2.3 or 2.4 directory.
+    # using a wildcard here is a trick (a bit dirty) to get both
+    # possibilities.
+    # It would give troubles only in the case for some reason both 
+    # 2.3 and 2.4 (or other) version directories have bee built.
+    # But I am pretty confident this will never happen.
+    #
+    #               Gianluca
+    #
+    chmod a+x $PYTHON_ROOT/bin/omniidl
+    cd $PYTHON_ROOT/lib/python*
+    $PYTHON_ROOT/bin/omniidl -I. -I$PYTHON_ROOT/idl -I$PYTHON_ROOT/idl/COS -bpython $PYTHON_ROOT/idl/COS/CosNotif*.idl \
+                                                                                $PYTHON_ROOT/idl/COS/CosEvent*.idl \
+                                                                                $PYTHON_ROOT/idl/COS/CosProper*.idl
+    
+    # omniORB does not come with TAO's AVStreams library so we must 
+    # compile the stubs ourselves.
+    $PYTHON_ROOT/bin/omniidl -I. -I$PYTHON_ROOT/idl -I$PYTHON_ROOT/idl/COS -bpython $ACE_ROOT/TAO/orbsvcs/orbsvcs/AVStreams.idl
+    
+    # there is problem with omniORB which assumes that the idl module name corespond to the name of the file
+    # This is not true for CosPropertyService which is in CosProperty.idl file, but module name is CosPropertyService
+    #
+    $PYTHON_ROOT/bin/omniidl -I. -I$PYTHON_ROOT/idl -I$PYTHON_ROOT/idl/COS -bpython $PYTHON_ROOT/idl/COS/CosProperty.idl
+    
+    #Make omniidl able to install in a non standard location
+    #See ticket COMP-5526
+    #export OMNI_ROOT_PATH=$(echo $OMNI_ROOT | sed -e 's/\//\\\//g') 
+    # cat $OMNI_ROOT/bin/omniidl | sed -e s/\""$OMNI_ROOT_PATH"/os\.getenv\(\"OMNI_ROOT\"\)\ \+\ \"/g > $OMNI_ROOT/bin/omniidl.new
+    # mv $OMNI_ROOT/bin/omniidl.new $OMNI_ROOT/bin/omniidl
+    
+    cd $CWD
+}
+
+build_omniorb_for_python "$(python2-config --prefix)"
+build_omniorb_for_python "$(python3.9-config --prefix)"
+
+eval "$(pyenv init -)"
+
+echo omniORB installation done!
+date

--- a/ansible/roles/acs/templates/patches/ACS-2021DEC/buildPyModules
+++ b/ansible/roles/acs/templates/patches/ACS-2021DEC/buildPyModules
@@ -1,0 +1,122 @@
+#! /bin/bash
+#*******************************************************************************
+# E.S.O. - ALMA project
+#
+# "@(#) $Id$"
+#
+# who        when        what
+# --------   ----------  ----------------------------------------------
+# agrimstrup 2007-07-10  created
+#
+
+#************************************************************************
+#   NAME
+#
+#   SYNOPSIS
+#
+#   DESCRIPTION
+#
+#   FILES
+#
+#   ENVIRONMENT
+#
+#   RETURN VALUES
+#
+#   CAUTIONS
+#
+#   EXAMPLES
+#
+#   SEE ALSO
+#
+#   BUGS
+#
+#------------------------------------------------------------------------
+#
+
+#
+# Install Python Modules
+#
+#set -x
+#export PYTHON_ROOT=/alma/$ALMASW_RELEASE/Python
+
+# Load functions
+. standardUtilities
+#
+# Fetch operating system and release version
+#
+os_discovery
+
+LOG=buildPyModules.log
+CWD=`pwd`
+#
+exec > $LOG 2>&1
+
+date
+
+PIP_VER=20.1.1
+
+if [ ! -d $PYTHON_ROOT ]
+then
+  echo "$PYTHON_ROOT not found, cannot continue..."
+  exit 1
+fi
+
+echo installing Python Modules
+
+echo $SEPARATOR
+if [ ${OS} = "LINUX" ] 
+then
+	echo "Installing on $DISTRO $OS version $REL"
+else
+	echo "Installing on $OS version $REL"
+fi
+
+if [     ${DISTRO}-${REL} != "SOLARIS-5.8"       \
+     -a  ${DISTRO}-${REL} != "RHLX-7.2"           \
+     -a  ${DISTRO}-${REL} != "RHLX-7.3"           \
+     -a  ${DISTRO}-${REL} != "RHLX-9"           \
+     -a  ${DISTRO}-${REL} != "RHEL-4"           \
+     -a  ${DISTRO}-${REL} != "RHEL-5"           \
+     -a  ${DISTRO}-${REL} != "RHEL-5.3"           \
+     -a  ${DISTRO}-${REL} != "SL-4.1"           \
+     -a  ${DISTRO}-${REL} != "SL-5.3"           \
+   ]
+then
+    echo "OS not supported. Proceeding as for Linux RH 9"
+    echo ""
+fi
+
+#
+# PyEnv
+#
+# Notes: See README for help
+#
+cd ../PRODUCTS
+
+eval "$(pyenv init -)"
+pip2 install --upgrade pip==$PIP_VER
+pip2 config --site set global.disable-pip-version-check true
+pip2 install --force-reinstall -r acs-py27.req || { echo "FAILED: Installing Python 2 ACS Requirements (req) for Python 2.7" && exit 1; }
+patch -p1 -d $(pip2 show pip |grep Location |awk '{print $2}')/pip < ../PRODUCTS/pip.patch || { echo "Failed to apply patch for Pip in Python 2" && exit 1; }
+patch -p1 -d $(pip2 show PyXB |grep Location |awk '{print $2}')/pyxb < ../PRODUCTS/pyxb.patch || { echo "Failed to apply patch for PyXB in Python 2" && exit 1; }
+cp acs-py27.req $(python2-config --prefix)/acs-py.req
+
+pip3.9 install --upgrade pip==$PIP_VER
+pip3.9 config --site set global.disable-pip-version-check true
+pip3.9 install --force-reinstall -r acs-py3.req || { echo "FAILED: Installing Python 3 ACS Requirements (req) for Python 3.9" && exit 1; }
+patch -p1 -d $(pip3.9 show pip |grep Location |awk '{print $2}')/pip < ../PRODUCTS/pip.patch || { echo "Failed to apply patch for Pip in Python 3.9" && exit 1; }
+patch -p1 -d $(pip3.9 show PyXB |grep Location |awk '{print $2}')/pyxb < ../PRODUCTS/pyxb.patch || { echo "Failed to apply patch for PyXB in Python 3.9" && exit 1; }
+cp acs-py3.req $(python3.9-config --prefix)/acs-py.req
+
+cd $CWD
+result=$(grep Failed ${LOG}|wc -l)
+if [ $result -gt 0 ]
+then
+    echo "Python Module installation fail."
+    date
+    exit 1
+else
+    echo "Python Module installation done."
+fi
+
+date

--- a/ansible/roles/acs/templates/patches/ACS-2021DEC/buildPython
+++ b/ansible/roles/acs/templates/patches/ACS-2021DEC/buildPython
@@ -1,0 +1,76 @@
+#! /bin/bash
+#*******************************************************************************
+# E.S.O. - ALMA project
+#
+# "@(#) $Id: buildPython,v 1.29 2013/03/01 11:37:54 eallaert Exp $"
+#
+# who       when        what
+# --------  ----------  ----------------------------------------------
+# psivera   2002-08-21  created
+# sturolla  2005-10-09  ported to bourne shell + add external subroutin for OS checking
+# agrimstrup 2007-07-10 modified build to create shared library for Python interpreter
+# agrimstrup 2007-08-22 updated Python to version 2.5.1 
+# eallaert  2013-03-01  determine Tcl/Tk version dynamically instead of hardcoding
+#
+
+#************************************************************************
+#   NAME
+#
+#   SYNOPSIS
+#
+#   DESCRIPTION
+#
+#   FILES
+#
+#   ENVIRONMENT
+#
+#   RETURN VALUES
+#
+#   CAUTIONS
+#
+#   EXAMPLES
+#
+#   SEE ALSO
+#
+#   BUGS
+#
+#------------------------------------------------------------------------
+#
+
+#
+# Install Python
+#
+#  See www.python.org for information.
+#
+# Retrieve the sources from: ftp.python.org
+#
+#set -x
+#export PYTHON_ROOT=/alma/$ALMASW_RELEASE/Python
+
+# Load functions
+. standardUtilities
+#
+# Fetch operating system and release version
+#
+os_discovery
+
+
+LOG=buildPython.log
+CWD=`pwd`
+#
+exec > $LOG 2>&1
+
+date
+
+PYENV_VER=v1.2.26
+git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT || (echo "FAILED: Cloning pyenv repository." && exit 1)
+cd $PYENV_ROOT && git checkout tags/$PYENV_VER -b pyenv-acs && cd - || (echo "FAILED: Checkout of $PYENV_VER tag version." && exit 1)
+eval "$(pyenv init -)" || (echo "FAILED: Initializing pyenv environment." && exit 1)
+PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install -f 2.7.16 || (echo "FAILED: Installing Python 2.7.16." && exit 1)
+PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install -f 3.9.4 || (echo "FAILED: Installing Python 3.9.4." && exit 1)
+pyenv global 3.9.4 2.7.16 || (echo "FAILED: Setting the global Python version" && exit 1)
+cp ../PRODUCTS/python-patches/compileall.py $(python2-config --prefix)/lib/python2.7 || (echo "FAILED: Copying compileall to Python 2.7." && exit 1)
+
+cd $CWD
+echo Python installation done!
+date


### PR DESCRIPTION
Replaced ACS Python 3.6.9 and 3.8.6 versions with 3.9.4 version.

This allows to retain compatibility with Pyenv major version (1) and to use a more updated version of Python 3. Everything DISCOS-related seems to be working properly.