### PR TITLE
Fix #371, updated the `discos-get` script

### DIFF
--- a/ansible/roles/acs/templates/discos-get
+++ b/ansible/roles/acs/templates/discos-get
@@ -11,7 +11,8 @@ if os.name == 'posix' and sys.version_info[0] < 3:
 else:
     import subprocess
 
-repository = 'https://github.com/discos/discos.git'
+https_url = 'https://github.com/discos/discos.git'
+ssh_url = 'git@github.com:discos/discos.git'
 
 STATION = ''
 try:
@@ -74,22 +75,29 @@ try:
     code = subprocess.call(
         ['git',
         'clone',
-        repository,
+        https_url,
         branch_name,
         '--branch',
-        args.target,
-        '--single-branch'],
+        args.target],
         timeout=120,
-        )
+    )
 except subprocess.TimeoutExpired:
     if os.path.exists(BRANCH_PATH):
         shutil.rmtree(BRANCH_PATH)
-    print('\nERROR: timeout expired cloning %s.' % repository)
+    print('\nERROR: timeout expired cloning %s.' % https_url)
     sys.stderr.flush()
     sys.exit(-1)
 if code:
     sys.exit(code)
 else:
+    # Change the push url of the repository
+    code = subprocess.call(
+        ['git',
+        'config',
+        'remote.origin.pushurl',
+        ssh_url],
+        cwd=BRANCH_PATH
+    )
     os.symlink(
         '/{{ discos_sw_dir }}/SlaLibrary',
         '%s/Common/Libraries/SlaLibrary' % BRANCH_PATH

--- a/ansible/roles/acs/templates/discos-get
+++ b/ansible/roles/acs/templates/discos-get
@@ -91,7 +91,7 @@ if code:
     sys.exit(code)
 else:
     # Change the push url of the repository
-    code = subprocess.call(
+    subprocess.call(
         ['git',
         'config',
         'remote.origin.pushurl',


### PR DESCRIPTION
This update allows to keep a fetchable repository (by using the https url), but enables to push any commit (by setting the pushurl to the ssh repository url).
The `--single-branch` argument was removed, since it prevented to switch between branches of the same repository (this limitation sometimes caused some issues when pushing some production patches to the remote repository).