### PR TITLE
Fix #471, enabled fixed resolution VNC

### DIFF
--- a/ansible/inventories/srt/group_vars/acs
+++ b/ansible/inventories/srt/group_vars/acs
@@ -3,3 +3,4 @@
 sardara_mount_point: "/roach2_nuraghe/data"
 sardara_ip_address: "dorian"
 sardara_remote_directory: "/raid/roach2_nuraghe"
+fixed_resolution_vnc: true

--- a/ansible/roles/acs/tasks/discos_dependencies.yml
+++ b/ansible/roles/acs/tasks/discos_dependencies.yml
@@ -581,7 +581,7 @@
 
 - name: Check if PyQtQwt is installed
   ansible.builtin.stat:
-    path: "/alma/{{ acs_tag }}/pyenv/versions/3.6.9/share/sip/PyQt4/Qwt"
+    path: "/alma/{{ acs_tag }}/pyenv/versions/3.9.4/share/sip/PyQt4/Qwt"
   register: pyqtqwt_library
 
 

--- a/ansible/roles/vnc/defaults/main.yml
+++ b/ansible/roles/vnc/defaults/main.yml
@@ -2,3 +2,5 @@
 
 vnc_starting_port: 15000
 vnc_resolution: "1920x1080"
+fixed_resolution_vnc: false
+fixed_resolution_vnc_offset: 10

--- a/ansible/roles/vnc/templates/vncserver@:user.service
+++ b/ansible/roles/vnc/templates/vncserver@:user.service
@@ -35,12 +35,9 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-
-# Clean any existing files in /tmp/.X11-unix environment
-ExecStartPre=/bin/sh -c '/usr/bin/vncserver -kill %i > /dev/null 2>&1 || :'
-ExecStart=/sbin/runuser -l {{ item.value.name }} -c "/usr/bin/vncserver :{{ item.value.vnc_port_offset }} -name {{ inventory_hostname_short }}-{{ item.value.name }} -SecurityTypes None -geometry {{ vnc_resolution }} -depth 32 -AlwaysShared -nolisten tcp -rfbport {{ vnc_starting_port+item.value.vnc_port_offset|int }}"
-PIDFile=/discos-sw/{{ item.value.name }}/.vnc/%H%i.pid
-ExecStop=/bin/sh -c '/usr/bin/vncserver -kill %i > /dev/null 2>&1 || :'
+ExecStart=/usr/sbin/runuser -l {{ item.value.name }} -c "/usr/bin/vncserver :{{ item.value.vnc_port_offset|int }} -name {{ inventory_hostname_short }}_{{ item.value.name }} -SecurityTypes None -geometry 1920x1080 -depth 32 -AlwaysShared -nolisten tcp -rfbport {{ vnc_starting_port+item.value.vnc_port_offset|int }} || :{% if fixed_resolution_vnc %} && /bin/x11vnc -display :{{ item.value.vnc_port_offset|int }} -nowireframe -rfbport {{ vnc_starting_port+fixed_resolution_vnc_offset+item.value.vnc_port_offset|int }} -nopw -forever -shared -bg -localhost -tag {{ inventory_hostname_short }}_{{ item.value.name }}{% endif %}"
+ExecStop=/usr/sbin/runuser -l {{ item.value.name }} -c "{% if fixed_resolution_vnc %}/usr/bin/pkill -s 9 -f 'x11vnc.*{{ inventory_hostname_short }}_{{ item.value.name }}' || : && {% endif %}/usr/bin/vncserver -kill :{{ item.value.vnc_port_offset|int }} || :"
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The fixed resolution VNC session is just a secondary export of the original VNC session, but with no session resizing capabilities. These sessions are the ones that will be shared with the wide area network in order to keep the resolution the same as the control room viewers configuration.

Also, fixed a check for PyQtQwt installation.