### PR TITLE
Fix #499, project users can traverse some dirs

### DIFF
--- a/ansible/roles/manager/tasks/archive_tree.yml
+++ b/ansible/roles/manager/tasks/archive_tree.yml
@@ -24,7 +24,7 @@
     state: present
   with_nested:
     - ["data", "extraData", "schedules"]
-    - ["user::rwx", "group::---"]
+    - ["user::rwx", "group::--x"]
 
 
 - name: Render the discos-logrotate template


### PR DESCRIPTION
The `data`, `extraData` and `schedules` directories can now be traversed by project users by default. This was the original intended behavior.