### PR TITLE
Fix #499, fixed the discos-archive/* permissions

### DIFF
--- a/ansible/roles/manager/tasks/archive_tree.yml
+++ b/ansible/roles/manager/tasks/archive_tree.yml
@@ -7,7 +7,7 @@
     owner: "{{ user.name }}"
     group: "{{ item.group }}"
     mode: "{{ item.mode }}"
-    recurse: true
+    recurse: false
     follow: true
   with_items:
     - { path: "data", group: "{{ users_groups.projects }}", mode: "0710" }


### PR DESCRIPTION
The `recurse` parameter used to overwrite the permissions of the directories inside the showed ones. This caused that a user called `Maintenance` could not read the content of the `schedules/Maintenance`, `data/Maintenance` and `extraData/Maintenance` anymore if a provisioning procedure was executed again after the said directories creation.