### PR TITLE
Fix #504, call `ifrCacheInvalidate` in discos-get

### DIFF
--- a/ansible/roles/acs/templates/discos-get
+++ b/ansible/roles/acs/templates/discos-get
@@ -106,6 +106,9 @@ else:
     )
     print('Repository cloned into %s' % BRANCH_PATH)
 
+# Call ifrCacheInvalidate before creating the INTROOT
+FNULL = open(os.devnull, 'w')
+subprocess.call(['ifrCacheInvalidate'], stdout=FNULL, stderr=FNULL)
 
 # Create the introot inside /{{ discos_sw_dir }}/introots/
 introot = os.path.join('/{{ discos_sw_dir }}/introots', branch_name)


### PR DESCRIPTION
This allow for a cleaner INTROOT generation