### PR TITLE
Fix #389, automatically update the discos/doc repository

### DIFF
--- a/.github/workflows/doc_update.yml
+++ b/.github/workflows/doc_update.yml
@@ -6,10 +6,10 @@ on:
     branches:
       - master
     paths:
-      - 'doc/*'
+      - 'doc/**'
 
 jobs:
-  updatedoc:
+  update-local-doc:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: "${{ secrets.GH_WORKFLOWS_TOKEN }}"
@@ -17,13 +17,28 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3
-        check-latest: true
     - name: Split subtree and push to doc branch
       run: |
         git subtree split --prefix=doc -b doc
-        git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git
+        git checkout doc
+        rm -rf conf.py doc_requirements.txt .gitignore Makefile _static _templates
+        git add -u
+        git commit --amend --no-edit
         git push --force origin doc:doc
+
+  update-remote-doc:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: "${{ secrets.GH_WORKFLOWS_TOKEN }}"
+    needs: update-local-doc
+    steps:
+    - name: Checkout the doc repository
+      uses: actions/checkout@v4
+      with:
+        repository: discos/doc
+        ref: fix-issue-47
+    - name: Update the doc repository
+      run: |
+        git subtree pull --prefix=developer/howto/installing ${{ github.repositoryUrl }} doc --squash --message \
+          "Merging updates from deployment repository:\n\n$(curl -s https://api.github.com/repos/${{ github.repository }}/commits?sha=doc\&per_page=1 | jq -r '.[0].commit.message')"
+        git push origin fix-issue-47

--- a/.github/workflows/doc_update.yml
+++ b/.github/workflows/doc_update.yml
@@ -19,7 +19,8 @@ jobs:
         fetch-depth: 0
     - name: Split subtree and push to doc branch
       run: |
-        git remote set-url origin https://x-access-token:${{ secrets.GH_WORKFLOWS_TOKEN }}@github.com/${{ github.repository }}
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
         git subtree split --prefix=doc -b doc
         git checkout doc
         rm -rf conf.py doc_requirements.txt .gitignore Makefile _static _templates

--- a/.github/workflows/doc_update.yml
+++ b/.github/workflows/doc_update.yml
@@ -19,6 +19,7 @@ jobs:
         fetch-depth: 0
     - name: Split subtree and push to doc branch
       run: |
+        git remote set-url origin https://x-access-token:${{ secrets.GH_WORKFLOWS_TOKEN }}@github.com/${{ github.repository }}
         git subtree split --prefix=doc -b doc
         git checkout doc
         rm -rf conf.py doc_requirements.txt .gitignore Makefile _static _templates

--- a/.github/workflows/doc_update.yml
+++ b/.github/workflows/doc_update.yml
@@ -41,6 +41,6 @@ jobs:
         ref: fix-issue-47
     - name: Update the doc repository
       run: |
-        git subtree pull --prefix=developer/howto/installing ${{ github.repositoryUrl }} doc --squash --message \
+        git subtree pull --prefix=developer/howto/installing https://github.com/${{ github.repository }}.git doc --squash --message \
           "Merging updates from deployment repository:\n\n$(curl -s https://api.github.com/repos/${{ github.repository }}/commits?sha=doc\&per_page=1 | jq -r '.[0].commit.message')"
         git push origin fix-issue-47

--- a/.github/workflows/doc_update.yml
+++ b/.github/workflows/doc_update.yml
@@ -30,17 +30,18 @@ jobs:
 
   update-remote-doc:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: "${{ secrets.GH_WORKFLOWS_TOKEN }}"
     needs: update-local-doc
     steps:
     - name: Checkout the doc repository
       uses: actions/checkout@v4
       with:
         repository: discos/doc
-        ref: fix-issue-47
+        fetch-depth: 0
+        token: "${{ secrets.GH_WORKFLOWS_TOKEN }}"
     - name: Update the doc repository
       run: |
-        git subtree pull --prefix=developer/howto/installing https://github.com/${{ github.repository }}.git doc --squash --message \
-          "Merging updates from deployment repository:\n\n$(curl -s https://api.github.com/repos/${{ github.repository }}/commits?sha=doc\&per_page=1 | jq -r '.[0].commit.message')"
-        git push origin fix-issue-47
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        MESSAGE="Merging updates from deployment repository:\n\n$(curl -s https://api.github.com/repos/${{ github.repository }}/commits?sha=doc\&per_page=1 | jq -r '.[0].commit.message')"
+        git subtree pull --prefix=developer/howto/installing https://github.com/${{ github.repository }}.git doc --squash --message "$(echo -e "$MESSAGE")"
+        git push


### PR DESCRIPTION
The workflow file that was modified in this PR handles the push of this repository doc branch onto the developer/howto/installing directory of the discos/doc repository.
The doc branch is always automatically generated whenever a modification under the `doc` path of the master branch (and only the master branch) is detected.
With this workflow we can keep the master branch of the discos/doc repository always and automatically aligned with the doc directory of this repository master branch.

This should only be merged after merging [the related PR](https://github.com/discos/doc/pull/65) on the doc repo.