### PR TITLE
Fix #511, added patch for acsMakefileDefinitions

### DIFF
--- a/ansible/roles/acs/tasks/patches/ACS-2021DEC.yml
+++ b/ansible/roles/acs/tasks/patches/ACS-2021DEC.yml
@@ -35,6 +35,16 @@
     - "cdb_rdb/src/rules.mk"
 
 
+- name: Patch lockfile timeout in acsMakefileDefinitions.mk
+  ansible.builtin.replace:
+    dest: "{{ remote_build_path }}/acs/{{ item }}"
+    regexp: 'lockfile -s 2 -r 10(.*\.make-OmniOrb\.lock)'
+    replace: 'lockfile -s 1 -r 60\g<1>'
+  with_items:
+    - "LGPL/Kit/acs/include/acsMakefileDefinitions.mk"
+    - "ExtProd/PRODUCTS/acs-ext/expat/make/acsMakefileDefinitions.mk"
+
+
 - name: Set some paths
   ansible.builtin.set_fact:
     acs_command_center: "{{ item }}"


### PR DESCRIPTION
We wait a single second and retry for 60 times instead of waiting 2 seconds and retrying only 10 times.